### PR TITLE
Fix add_message docstring

### DIFF
--- a/contract_schema/document.py
+++ b/contract_schema/document.py
@@ -23,21 +23,32 @@ class Document(dict):
             self["initialization_dtg"] = utils._now_iso()
 
     def add_message(self, level: str, text: str) -> None:
-        if (self.__finalised == True):
-            return None
+        """Add a timestamped log message to the document, if supported.
 
-        """Adds a timestamped log message to the document, if schema supports it."""
+        The method is a no-op once :meth:`finalise` has been called and the
+        document is immutable.  When the underlying schema lacks a ``messages``
+        field a :class:`NotImplementedError` is raised to signal that the
+        feature isn't available for the current contract.
+        """
+
+        if self.__finalised:
+            return
+
         if "messages" not in self.__schema.get("fields", {}):
-            raise NotImplementedError("This document's schema does not support 'messages'.")
-        
+            raise NotImplementedError(
+                "This document's schema does not support 'messages'."
+            )
+
         if "messages" not in self:
             self["messages"] = []
-        
-        self["messages"].append({
-            "timestamp": utils._now_iso(),
-            "level": level.upper(),
-            "text": text,
-        })
+
+        self["messages"].append(
+            {
+                "timestamp": utils._now_iso(),
+                "level": level.upper(),
+                "text": text,
+            }
+        )
 
     def finalise(self) -> None:
         """Populate select meta fields, then validate."""

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -143,3 +143,8 @@ class DocumentTests(unittest.TestCase):
 
         # --- runtime seconds --------------------------------------------
         self.assertGreaterEqual(doc["total_runtime_seconds"], 0)
+
+    def test_add_message_has_docstring(self):
+        """Regression: ensure add_message exposes its docstring."""
+        self.assertIsNotNone(Document.add_message.__doc__)
+        self.assertIn("timestamped log message", Document.add_message.__doc__)


### PR DESCRIPTION
## Summary
- ensure Document.add_message includes an accessible docstring and honours finalisation
- add regression test for add_message docstring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898fbb891f48332867d0e73c9daf0d3