### PR TITLE
Clarify message logging after finalization

### DIFF
--- a/contract_schema/document.py
+++ b/contract_schema/document.py
@@ -23,10 +23,13 @@ class Document(dict):
             self["initialization_dtg"] = utils._now_iso()
 
     def add_message(self, level: str, text: str) -> None:
-        if (self.__finalised == True):
-            return None
+        """Adds a timestamped log message to the document, if schema supports it.
 
-        """Adds a timestamped log message to the document, if schema supports it."""
+        If this document has already been finalised, the message will not be
+        recorded.
+        """
+        if self.__finalised:
+            return None
         if "messages" not in self.__schema.get("fields", {}):
             raise NotImplementedError("This document's schema does not support 'messages'.")
         
@@ -93,6 +96,6 @@ class Document(dict):
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
-            json.dumps(self, indent=indent, ensure_ascii=False), 
+            json.dumps(self, indent=indent, ensure_ascii=False),
             encoding="utf-8"
         )


### PR DESCRIPTION
## Summary
- place docstring first in `add_message` and clarify behavior when document is finalized
- move finalized guard below docstring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898fe7fa26c8332930a11a6b2481995