### PR TITLE
Check timestamps before computing runtime

### DIFF
--- a/contract_schema/document.py
+++ b/contract_schema/document.py
@@ -51,9 +51,24 @@ class Document(dict):
             self["finalization_dtg"] = now_iso
         
         if "total_runtime_seconds" in self.__schema.get("fields", {}):
-            init_dt = _dt.datetime.fromisoformat(self["initialization_dtg"].replace("Z", "+00:00"))
-            end_dt = _dt.datetime.fromisoformat(self["finalization_dtg"].replace("Z", "+00:00"))
-            self["total_runtime_seconds"] = int((end_dt - init_dt).total_seconds())
+            init_dtg = self.get("initialization_dtg")
+            final_dtg = self.get("finalization_dtg")
+            if init_dtg and final_dtg:
+                init_dt = _dt.datetime.fromisoformat(init_dtg.replace("Z", "+00:00"))
+                end_dt = _dt.datetime.fromisoformat(final_dtg.replace("Z", "+00:00"))
+                self["total_runtime_seconds"] = int((end_dt - init_dt).total_seconds())
+            else:
+                missing = [
+                    field
+                    for field, value in (
+                        ("initialization_dtg", init_dtg),
+                        ("finalization_dtg", final_dtg),
+                    )
+                    if value is None
+                ]
+                raise KeyError(
+                    "Cannot compute total_runtime_seconds without: " + ", ".join(missing)
+                )
         
         if "run_id" in self.__schema.get("fields", {}):
             self["run_id"] = str(uuid.uuid4())

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -143,3 +143,44 @@ class DocumentTests(unittest.TestCase):
 
         # --- runtime seconds --------------------------------------------
         self.assertGreaterEqual(doc["total_runtime_seconds"], 0)
+
+    def test_finalise_missing_initialization_dtg_raises(self):
+        schema = {
+            "title": "MissingInit",
+            "type": "object",
+            "fields": {
+                "finalization_dtg": {"type": ["string"], "format": "date-time"},
+                "total_runtime_seconds": {"type": ["integer"]},
+            },
+            "additionalProperties": False,
+        }
+        doc = Document(schema=schema)
+        with self.assertRaises(KeyError):
+            doc.finalise()
+
+    def test_finalise_missing_finalization_dtg_raises(self):
+        schema = {
+            "title": "MissingFinal",
+            "type": "object",
+            "fields": {
+                "initialization_dtg": {"type": ["string"], "format": "date-time"},
+                "total_runtime_seconds": {"type": ["integer"]},
+            },
+            "additionalProperties": False,
+        }
+        doc = Document(schema=schema)
+        with self.assertRaises(KeyError):
+            doc.finalise()
+
+    def test_finalise_missing_both_dtg_raises(self):
+        schema = {
+            "title": "MissingBoth",
+            "type": "object",
+            "fields": {
+                "total_runtime_seconds": {"type": ["integer"]},
+            },
+            "additionalProperties": False,
+        }
+        doc = Document(schema=schema)
+        with self.assertRaises(KeyError):
+            doc.finalise()


### PR DESCRIPTION
## Summary
- Verify initialization and finalization timestamps exist before calculating runtime
- Add tests ensuring missing timestamp scenarios raise clear errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898fe7e5cf88332a09578f7523cd4eb